### PR TITLE
Docker will respect allocated host port if Broker assigns them

### DIFF
--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -363,7 +363,6 @@ class DockerManager < ContainerManager
       image_expose_ports = container.json.fetch('Config', {}).fetch('ExposedPorts', {})
       Hash[image_expose_ports.map { |ep, _| [ep, [{}]] }]
     else
-      # Hash[expose_ports.map { |ep| [ep, [{}]] }]
       Hash[expose_ports.map { |ep| [ep, [{'HostPort' => allocate_host_port.to_s}]] }]
     end
   end

--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -348,13 +348,21 @@ class DockerManager < ContainerManager
   end
 
   def port_bindings(guid)
+    # 'PortBindings' => { '5000/tcp' => [{ 'HostPort' => '5000' }] }
     if expose_ports.empty?
       container = find(guid)
       image_expose_ports = container.json.fetch('Config', {}).fetch('ExposedPorts', {})
       Hash[image_expose_ports.map { |ep, _| [ep, [{}]] }]
     else
-      Hash[expose_ports.map { |ep| [ep, [{}]] }]
+      # Hash[expose_ports.map { |ep| [ep, [{}]] }]
+      Hash[expose_ports.map { |ep| [ep, [{'HostPort' => allocate_host_port.to_s}]] }]
     end
+  end
+
+  # Allocates the next available host port
+  def allocate_host_port
+    @allocate_host_port ||= 9999
+    @allocate_host_port += 1
   end
 
   def bound_ports(container)

--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -347,6 +347,15 @@ class DockerManager < ContainerManager
     Settings.host_directory
   end
 
+  def host_port_allocator
+    @host_port_allocator ||= HostPortAllocator.new(host_directory, 10000, 63000)
+  end
+
+  # Allocates the next available host port
+  def allocate_host_port
+    host_port_allocator.allocate_next_port
+  end
+
   def port_bindings(guid)
     # 'PortBindings' => { '5000/tcp' => [{ 'HostPort' => '5000' }] }
     if expose_ports.empty?
@@ -357,12 +366,6 @@ class DockerManager < ContainerManager
       # Hash[expose_ports.map { |ep| [ep, [{}]] }]
       Hash[expose_ports.map { |ep| [ep, [{'HostPort' => allocate_host_port.to_s}]] }]
     end
-  end
-
-  # Allocates the next available host port
-  def allocate_host_port
-    @allocate_host_port ||= 9999
-    @allocate_host_port += 1
   end
 
   def bound_ports(container)

--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -361,7 +361,7 @@ class DockerManager < ContainerManager
     if expose_ports.empty?
       container = find(guid)
       image_expose_ports = container.json.fetch('Config', {}).fetch('ExposedPorts', {})
-      Hash[image_expose_ports.map { |ep, _| [ep, [{}]] }]
+      Hash[image_expose_ports.map { |ep, _| [ep, [{'HostPort' => allocate_host_port.to_s}]] }]
     else
       Hash[expose_ports.map { |ep| [ep, [{'HostPort' => allocate_host_port.to_s}]] }]
     end

--- a/app/models/host_port_allocator.rb
+++ b/app/models/host_port_allocator.rb
@@ -49,6 +49,11 @@ class HostPortAllocator
   end
 
   def port_available?(port)
-    true
+    port_open?(port)
+  end
+
+  # http://stackoverflow.com/a/22752150/36170
+  def port_open?(port)
+    !system("lsof -i:#{port}", out: '/dev/null')
   end
 end

--- a/app/models/host_port_allocator.rb
+++ b/app/models/host_port_allocator.rb
@@ -1,3 +1,7 @@
+# HostPortAllocator allows a server to allocate ports for containers
+# It uses a local /var/vcap/store/cf-containers-broker/host_port_counter
+# file to store the last port allocated. It uses lsof to confirm that a port
+# to be allocated is not currently being used.
 class HostPortAllocator
   attr_reader :counter_path
 

--- a/app/models/host_port_allocator.rb
+++ b/app/models/host_port_allocator.rb
@@ -1,0 +1,34 @@
+class HostPortAllocator
+  attr_reader :counter_path
+
+  class LockTimeout < StandardError; end
+
+  def initialize(base_dir, counter_start, counter_end)
+    @base_dir = base_dir
+    @counter_path = File.join(@base_dir, 'host_port_counter')
+    @counter_start, @counter_end = counter_start, counter_end
+  end
+
+  def allocate_next_port
+    port = nil
+    File.open(counter_path, File::RDWR|File::CREAT, 0644) do |f|
+      # TODO perhaps assume that if lock isn't released then recreate and restart counter
+      Timeout::timeout(1, LockTimeout) { f.flock(File::LOCK_EX) }
+      previous_port = f.read.to_i
+      if previous_port < @counter_start
+        port = @counter_start
+      else
+        port = previous_port + 1
+      end
+      if port > @counter_end
+        port = @counter_start
+      end
+      f.rewind
+      f.write("#{port}\n")
+      f.flush
+      f.truncate(f.pos)
+      f.flock(File::LOCK_UN)
+    end
+    port
+  end
+end

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -233,6 +233,14 @@ describe DockerManager do
     end
   end
 
+  describe '#allocate_host_port (private)' do
+    it 'should allocate consecutive ports' do
+      expect(subject.send(:allocate_host_port)).to eq(10000)
+      expect(subject.send(:allocate_host_port)).to eq(10001)
+      expect(subject.send(:allocate_host_port)).to eq(10002)
+    end
+  end
+
   describe '#can_allocate?' do
     context 'when the number of existing containers does not exceed max_containers' do
       it 'should return true' do
@@ -302,13 +310,13 @@ describe DockerManager do
     }
     let(:env_vars) { ['USER=MY-USER'] }
     let(:binds) { [] }
-    let(:port_bindings) { { expose_port => [{}] } }
+    let(:port_bindings) { { expose_port => [{'HostPort' => '10000'}] } }
     let(:persistent_volume) { nil }
     let(:container_running) { true }
     let(:container_state) {
       {
         'State' => { 'Running' => container_running },
-        'Config' => { 'ExposedPorts' => { container_expose_port => {} }},
+        'Config' => { 'ExposedPorts' => { container_expose_port => [{'HostPort' => '10000'}] }},
       }
     }
 

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -62,6 +62,7 @@ describe DockerManager do
   let(:persistent_volume) { '/data' }
   let(:restart) { 'on-failure:5' }
   let(:api_version) { DockerManager::MIN_SUPPORTED_DOCKER_API_VERSION }
+  let(:allocated_host_port) { 10000 }
 
   before do
     allow(Docker).to receive(:version).and_return({ 'ApiVersion' => api_version })
@@ -69,6 +70,7 @@ describe DockerManager do
     allow(credentials).to receive(:username_value).with(guid).and_return(username_value)
     allow(credentials).to receive(:password_value).with(guid).and_return(password_value)
     allow(credentials).to receive(:dbname_value).with(guid).and_return(dbname_value)
+    expect(subject).to receive(:allocate_host_port).and_return(10000).at_most(:once)
   end
 
   describe '#initialize' do
@@ -230,14 +232,6 @@ describe DockerManager do
           subject.find(guid)
         end.to raise_error(Docker::Error::IOError)
       end
-    end
-  end
-
-  describe '#allocate_host_port (private)' do
-    it 'should allocate consecutive ports' do
-      expect(subject.send(:allocate_host_port)).to eq(10000)
-      expect(subject.send(:allocate_host_port)).to eq(10001)
-      expect(subject.send(:allocate_host_port)).to eq(10002)
     end
   end
 

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -372,7 +372,7 @@ describe DockerManager do
 
     context 'when there are no exposed ports' do
       let(:expose_port) { nil }
-      let(:port_bindings) { { container_expose_port => [{}] } }
+      let(:port_bindings) { { container_expose_port => [{'HostPort' => '10000'}] } }
 
       it 'should expose the container image exposed ports' do
         expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)

--- a/spec/models/host_port_allocator_spec.rb
+++ b/spec/models/host_port_allocator_spec.rb
@@ -6,12 +6,19 @@ describe HostPortAllocator do
   before { FileUtils.rm_rf('/tmp/host_port_counter') }
   let(:subject) { described_class.new('/tmp', 10000, 10004) }
   it 'should allocate consecutive ports and wrap around' do
-    expect(subject.send(:allocate_next_port)).to eq(10000)
-    expect(subject.send(:allocate_next_port)).to eq(10001)
-    expect(subject.send(:allocate_next_port)).to eq(10002)
-    expect(subject.send(:allocate_next_port)).to eq(10003)
-    expect(subject.send(:allocate_next_port)).to eq(10004)
-    expect(subject.send(:allocate_next_port)).to eq(10000)
+    expect(subject.allocate_next_port).to eq(10000)
+    expect(subject.allocate_next_port).to eq(10001)
+    expect(subject.allocate_next_port).to eq(10002)
+    expect(subject.allocate_next_port).to eq(10003)
+    expect(subject.allocate_next_port).to eq(10004)
+    expect(subject.allocate_next_port).to eq(10000)
+  end
+
+  it 'should skip unavailable ports' do
+    expect(subject).to receive(:port_available?).with(10000).and_return(false)
+    expect(subject).to receive(:port_available?).with(10001).and_return(false)
+    expect(subject).to receive(:port_available?).with(10002).and_return(true)
+    expect(subject.allocate_next_port).to eq(10002)
   end
 
   it 'should raise NoAvailablePort if cannot find a port' do

--- a/spec/models/host_port_allocator_spec.rb
+++ b/spec/models/host_port_allocator_spec.rb
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2014 Pivotal Software, Inc. All Rights Reserved.
+require 'spec_helper'
+
+describe HostPortAllocator do
+  before { FileUtils.rm_rf('/tmp/host_port_counter') }
+  let(:subject) { described_class.new('/tmp', 10000, 10004) }
+  it 'should allocate consecutive ports and wrap around' do
+    expect(subject.send(:allocate_next_port)).to eq(10000)
+    expect(subject.send(:allocate_next_port)).to eq(10001)
+    expect(subject.send(:allocate_next_port)).to eq(10002)
+    expect(subject.send(:allocate_next_port)).to eq(10003)
+    expect(subject.send(:allocate_next_port)).to eq(10004)
+    expect(subject.send(:allocate_next_port)).to eq(10000)
+  end
+end

--- a/spec/models/host_port_allocator_spec.rb
+++ b/spec/models/host_port_allocator_spec.rb
@@ -13,4 +13,12 @@ describe HostPortAllocator do
     expect(subject.send(:allocate_next_port)).to eq(10004)
     expect(subject.send(:allocate_next_port)).to eq(10000)
   end
+
+  it 'should raise NoAvailablePort if cannot find a port' do
+    expect(subject).to receive(:port_available?).and_return(false).at_least(:once)
+    expect(subject).to receive(:timeout_seconds).and_return(0.1).twice
+    expect {
+      subject.send(:allocate_next_port)
+    }.to raise_error(HostPortAllocator::NoAvailablePort)
+  end
 end


### PR DESCRIPTION
Introduces an atomic file `/var/vcap/store/cf-containers-broker/host_port_counter`
which starts at 10000 and wraps around at 63000. The algorithm uses `lsof` to
check if a proposed port is already being used or not.

* [ ] Confirm PR works in a bosh deployment
* [ ] Resolve the Docker API regression in tests; what's that about?