### PR TITLE
Work-around for Swarm API incompatibility with Docker

### DIFF
--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -217,6 +217,11 @@ class DockerManager < ContainerManager
 
   def validate_docker_remote_api
     api_version = Docker.version.fetch('ApiVersion', '0')
+    # Swarm returns API version with wrong key APIVersion instead of ApiVersion, so until
+    # https://github.com/docker/swarm/issues/687 is solved and released, work around this
+    if api_version == '0'
+      api_version = Docker.version.fetch('APIVersion', '0')
+    end
     unless api_version >= MIN_SUPPORTED_DOCKER_API_VERSION
       raise Exceptions::BackendError, "Docker Remote API version `#{api_version}' not supported"
     end


### PR DESCRIPTION
#### Purpose
Work-around for Swarm ReST-API incompatibility to Docker ReST-API

#### Motivation
The broker uses docker-api to talk to Docker, but it could in fact also talk to a Swarm that is supposed to be ReST-API compatible with Docker (with a few explicitly stated differences). However, Swarm is, in a minor detail, not Docker-compatible and breaks the broker when it talks to Swarm: The API version is returned under a differently spelled key, which we reported with https://github.com/docker/swarm/issues/687.

#### Proposal
Work-around the issue until https://github.com/docker/swarm/issues/687 gets fixed and released. This should happen with v0.3.0 and then this work-around can be removed again.

#### Changes
* Accept both spellings, ```APIVersion``` and ```ApiVersion``` when talking via docker-api to Docker or Swarm

#### Issues
Issue: https://github.com/docker/swarm/issues/687

#### CC
@frodenas @holgerkoser