### PR TITLE
Allow `cf update-service` to update docker container and/or change image/plan

### DIFF
--- a/app/controllers/v2/service_instances_controller.rb
+++ b/app/controllers/v2/service_instances_controller.rb
@@ -18,7 +18,8 @@ class V2::ServiceInstancesController < V2::BaseController
     begin
       if plan.container_manager.can_allocate?(Settings.max_containers, plan.max_containers)
         if plan.container_manager.find(instance_guid)
-          render status: 409, json: { 'description' => 'Service instance already exists' }
+          plan.container_manager.update(instance_guid, parameters)
+          render status: 200, json: {}
         else
           plan.container_manager.create(instance_guid, parameters)
           render status: 201, json: { dashboard_url: build_dashboard_url(service_guid,

--- a/app/models/container_manager.rb
+++ b/app/models/container_manager.rb
@@ -25,6 +25,10 @@ class ContainerManager
     raise Exceptions::NotImplemented, "`create' is not implemented by `#{self.class}'"
   end
 
+  def update(guid, parameters = {})
+    raise Exceptions::NotImplemented, "`update' is not implemented by `#{self.class}'"
+  end
+
   def destroy(guid)
     raise Exceptions::NotImplemented, "`destroy' is not implemented by `#{self.class}'"
   end

--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -79,6 +79,29 @@ class DockerManager < ContainerManager
     end
   end
 
+  def update(guid, parameters = {})
+    Rails.logger.info("Updating Docker container `#{container_name(guid)}'...")
+    unless container = find(guid)
+      raise Exceptions::NotFound, "Docker container `#{container_name(guid)}' not found"
+    end
+    container.kill
+    container.remove(v: true, force: true)
+
+    container_create_opts = create_options(guid, parameters)
+    Rails.logger.info("+-> Create/update options: #{container_create_opts.inspect}")
+    container = Docker::Container.create(container_create_opts)
+
+    container_start_opts = start_options(guid)
+    Rails.logger.info("Starting Docker container `#{container_name(guid)}'...")
+    Rails.logger.info("+-> Start options: #{container_start_opts.inspect}")
+    container.start(container_start_opts)
+
+    unless container_running?(container)
+      container.remove(v: true, force: true) rescue nil #nop
+      raise Exceptions::BackendError, "Cannot start Docker container `#{container_name(guid)}', volumes not deleted"
+    end
+  end
+
   def destroy(guid)
     Rails.logger.info("Destroying Docker container `#{container_name(guid)}'...")
     if container = find(guid)

--- a/app/models/docker_manager.rb
+++ b/app/models/docker_manager.rb
@@ -84,6 +84,7 @@ class DockerManager < ContainerManager
     unless container = find(guid)
       raise Exceptions::NotFound, "Docker container `#{container_name(guid)}' not found"
     end
+    port_bindings = container.json['HostConfig']['PortBindings']
     container.kill
     container.remove(v: true, force: true)
 
@@ -92,6 +93,7 @@ class DockerManager < ContainerManager
     container = Docker::Container.create(container_create_opts)
 
     container_start_opts = start_options(guid)
+    container_start_opts['PortBindings'] = port_bindings
     Rails.logger.info("Starting Docker container `#{container_name(guid)}'...")
     Rails.logger.info("+-> Start options: #{container_start_opts.inspect}")
     container.start(container_start_opts)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -3,7 +3,8 @@
 require Rails.root.join('app/models/plan')
 
 class Service
-  attr_reader :id, :name, :description, :bindable, :tags, :metadata, :requires, :plans, :dashboard_client
+  attr_reader :id, :name, :description, :bindable, :tags, :metadata, :requires, :plans
+  attr_reader :plan_updateable, :dashboard_client
 
   def self.build(attrs)
     plan_attrs = attrs['plans'] || []
@@ -22,6 +23,7 @@ class Service
     @metadata    = attrs.fetch('metadata', nil)
     @requires    = attrs.fetch('requires', []) || []
     @plans       = attrs.fetch('plans')
+    @plan_updateable  = attrs.fetch('plan_updateable', true) || true
     @dashboard_client = attrs.fetch('dashboard_client', {}) || {}
   end
 
@@ -35,6 +37,7 @@ class Service
       'metadata'         => metadata,
       'requires'         => requires,
       'plans'            => plans.map(&:to_hash),
+      'plan_updateable'  => plan_updateable,
       'dashboard_client' => dashboard_client,
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 CfContainersBroker::Application.routes.draw do
   namespace :v2 do
     resource :catalog, only: [:show]
-    resources :service_instances, only: [:update, :destroy] do
+    resources :service_instances, only: [:update, :patch, :destroy] do
       resources :service_bindings, only: [:update, :destroy]
     end
   end

--- a/spec/controllers/v2/service_instances_controller_spec.rb
+++ b/spec/controllers/v2/service_instances_controller_spec.rb
@@ -81,7 +81,10 @@ describe V2::ServiceInstancesController do
 
       it 'returns a 507' do
         expect(Catalog).to receive(:find_plan_by_guid).with(plan_id).and_return(plan)
-        expect(plan).to receive(:container_manager).and_return(container_manager)
+        expect(plan).to receive(:container_manager).and_return(container_manager).twice
+        expect(container_manager).to receive(:find)
+                                     .with(instance_id)
+                                     .and_return(nil)
         expect(container_manager).to receive(:can_allocate?)
                                      .with(max_containers, max_plan_containers)
                                      .and_return(can_allocate)
@@ -130,10 +133,8 @@ describe V2::ServiceInstancesController do
 
       before do
         expect(Catalog).to receive(:find_plan_by_guid).with(plan_id).and_return(plan)
-        expect(plan).to receive(:container_manager).exactly(3).and_return(container_manager)
-        expect(container_manager).to receive(:can_allocate?)
-                                     .with(max_containers, max_plan_containers)
-                                     .and_return(can_allocate)
+        expect(plan).to receive(:container_manager).exactly(2).and_return(container_manager)
+        expect(container_manager).to_not receive(:can_allocate?)
         expect(container_manager).to receive(:find).with(instance_id).and_return(instance)
         expect(container_manager).to receive(:update).with(instance_id, parameters)
       end

--- a/spec/models/docker_manager_spec.rb
+++ b/spec/models/docker_manager_spec.rb
@@ -265,7 +265,7 @@ describe DockerManager do
     end
   end
 
-  describe '#create' do
+  describe 'crud' do
     let(:container_create_opts) {
       {
         'name' => container_name,
@@ -330,147 +330,180 @@ describe DockerManager do
         'Config' => { 'ExposedPorts' => { container_expose_port => {} }},
       }
     }
+    describe '#create' do
 
-    it 'should create and start a container' do
-      expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
-      expect(container).to receive(:start).with(container_start_opts)
-      expect(container).to receive(:json).and_return(container_state)
-      subject.create(guid)
-    end
-
-    context 'when container cannot be started' do
-      let(:container_running) { false }
-
-      it 'should remove the failed container' do
+      it 'should create and start a container' do
         expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
         expect(container).to receive(:start).with(container_start_opts)
         expect(container).to receive(:json).and_return(container_state)
-        expect(container).to receive(:remove).with(v: true, force: true)
-        expect do
-          subject.create(guid)
-        end.to raise_error(Exceptions::BackendError, "Cannot start Docker container `#{container_name}'")
-      end
-    end
-
-    context 'when there are credentials' do
-      before do
-        expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
-        expect(container).to receive(:start).with(container_start_opts)
-        expect(container).to receive(:json).and_return(container_state)
-      end
-
-      context 'with a username key' do
-        let(:username_key) { 'USERNAME-KEY' }
-        let(:env_vars) { ['USER=MY-USER', "#{username_key}=#{username_value}"] }
-
-        it 'should inject the username environment variable' do
-          subject.create(guid)
-        end
-      end
-
-      context 'with a password key' do
-        let(:password_key) { 'PASSWORD-KEY' }
-        let(:env_vars) { ['USER=MY-USER', "#{password_key}=#{password_value}"] }
-
-        it 'should inject the password environment variable' do
-          subject.create(guid)
-        end
-      end
-
-      context 'with a dbname key' do
-        let(:dbname_key) { 'DBNAME-KEY' }
-        let(:env_vars) { ['USER=MY-USER', "#{dbname_key}=#{dbname_value}"] }
-
-        it 'should inject the dbname environment variable' do
-          subject.create(guid)
-        end
-      end
-    end
-
-    context 'when there are no exposed ports' do
-      let(:expose_port) { nil }
-      let(:port_bindings) { { container_expose_port => [{ 'HostPort' => host_port.to_s }] } }
-
-      it 'should expose the container image exposed ports' do
-        expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
-        expect(Docker::Container).to receive(:get).with(container_name).and_return(container)
-        expect(container).to receive(:start).with(container_start_opts)
-        expect(container).to receive(:json).twice.and_return(container_state)
         subject.create(guid)
       end
+
+      context 'when container cannot be started' do
+        let(:container_running) { false }
+
+        it 'should remove the failed container' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          expect(container).to receive(:remove).with(v: true, force: true)
+          expect do
+            subject.create(guid)
+          end.to raise_error(Exceptions::BackendError, "Cannot start Docker container `#{container_name}'")
+        end
+      end
+
+      context 'when there are credentials' do
+        before do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+        end
+
+        context 'with a username key' do
+          let(:username_key) { 'USERNAME-KEY' }
+          let(:env_vars) { ['USER=MY-USER', "#{username_key}=#{username_value}"] }
+
+          it 'should inject the username environment variable' do
+            subject.create(guid)
+          end
+        end
+
+        context 'with a password key' do
+          let(:password_key) { 'PASSWORD-KEY' }
+          let(:env_vars) { ['USER=MY-USER', "#{password_key}=#{password_value}"] }
+
+          it 'should inject the password environment variable' do
+            subject.create(guid)
+          end
+        end
+
+        context 'with a dbname key' do
+          let(:dbname_key) { 'DBNAME-KEY' }
+          let(:env_vars) { ['USER=MY-USER', "#{dbname_key}=#{dbname_value}"] }
+
+          it 'should inject the dbname environment variable' do
+            subject.create(guid)
+          end
+        end
+      end
+
+      context 'when there are no exposed ports' do
+        let(:expose_port) { nil }
+        let(:port_bindings) { { container_expose_port => [{ 'HostPort' => host_port.to_s }] } }
+
+        it 'should expose the container image exposed ports' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(Docker::Container).to receive(:get).with(container_name).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).twice.and_return(container_state)
+          subject.create(guid)
+        end
+      end
+
+      context 'when there are persistent volumes' do
+        let(:persistent_volume) { '/data' }
+        let(:binds) { ["/tmp/#{container_name}#{persistent_volume}:#{persistent_volume}"] }
+
+        it 'should create a host directory and mount it to the container' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(Settings).to receive(:host_directory).and_return('/tmp')
+          expect(FileUtils).to receive(:mkdir_p).with("/tmp/#{container_name}#{persistent_volume}")
+          expect(FileUtils).to receive(:chmod_R).with(0777, "/tmp/#{container_name}#{persistent_volume}")
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          subject.create(guid)
+        end
+      end
+
+      context 'when restart policy does not include a retry count' do
+        let(:restart) { 'no' }
+        let(:container_start_opts) {
+          {
+            'Links' => [],
+            'LxcConf' => {},
+            'Memory' => 512 * 1024 * 1024,
+            'MemorySwap' => 256 * 1024 * 1024,
+            'CpuShares' => 0.1,
+            'PortBindings' => port_bindings,
+            'PublishAllPorts' => false,
+            'Privileged' => true,
+            'ReadonlyRootfs' => false,
+            'VolumesFrom' => [],
+            'CapAdd' => ['NET_ADMIN'],
+            'CapDrop' => ['CHOWN'],
+            'RestartPolicy' => {
+              'Name' => restart,
+            },
+            'Devices' => [],
+            'Ulimits' => [],
+          }
+        }
+
+        it 'should not add it at the start options' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          subject.create(guid)
+        end
+      end
+
+      context 'when allocate_docker_host_ports is not set' do
+        let(:port_bindings) { { expose_port => [{}] } }
+
+        before do
+          expect(Settings).to receive(:[]).with('allocate_docker_host_ports').and_return(false)
+        end
+
+        it 'should not add host port bindings when starting a container' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          subject.create(guid)
+        end
+      end
+
+      context 'when there are service arbitrary parameters' do
+        let(:parameters) { { 'foo' => 'bar', 'bar' => 'foo' } }
+        let(:env_vars) { ['USER=MY-USER', 'foo=bar', 'bar=foo'] }
+
+        it 'should pass the arbitrary parameters as environment variables' do
+          expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+          expect(container).to receive(:start).with(container_start_opts)
+          expect(container).to receive(:json).and_return(container_state)
+          subject.create(guid, parameters)
+        end
+      end
     end
 
-    context 'when there are persistent volumes' do
+    describe '#update' do
       let(:persistent_volume) { '/data' }
       let(:binds) { ["/tmp/#{container_name}#{persistent_volume}:#{persistent_volume}"] }
 
-      it 'should create a host directory and mount it to the container' do
+      it 'should kill then recreate the container with existing persistent data' do
+        expect(Docker::Container).to receive(:get).with(container_name).and_return(container)
+        expect(container).to receive(:kill)
+        expect(container).to receive(:remove).with(v: true, force: true)
+
         expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
+        # idempotently recreates existing volume folder on host machine
         expect(Settings).to receive(:host_directory).and_return('/tmp')
         expect(FileUtils).to receive(:mkdir_p).with("/tmp/#{container_name}#{persistent_volume}")
         expect(FileUtils).to receive(:chmod_R).with(0777, "/tmp/#{container_name}#{persistent_volume}")
+
         expect(container).to receive(:start).with(container_start_opts)
         expect(container).to receive(:json).and_return(container_state)
-        subject.create(guid)
-      end
-    end
 
-    context 'when restart policy does not include a retry count' do
-      let(:restart) { 'no' }
-      let(:container_start_opts) {
-        {
-          'Links' => [],
-          'LxcConf' => {},
-          'Memory' => 512 * 1024 * 1024,
-          'MemorySwap' => 256 * 1024 * 1024,
-          'CpuShares' => 0.1,
-          'PortBindings' => port_bindings,
-          'PublishAllPorts' => false,
-          'Privileged' => true,
-          'ReadonlyRootfs' => false,
-          'VolumesFrom' => [],
-          'CapAdd' => ['NET_ADMIN'],
-          'CapDrop' => ['CHOWN'],
-          'RestartPolicy' => {
-            'Name' => restart,
-          },
-          'Devices' => [],
-          'Ulimits' => [],
-        }
-      }
-
-      it 'should not add it at the start options' do
-        expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
-        expect(container).to receive(:start).with(container_start_opts)
-        expect(container).to receive(:json).and_return(container_state)
-        subject.create(guid)
-      end
-    end
-
-    context 'when allocate_docker_host_ports is not set' do
-      let(:port_bindings) { { expose_port => [{}] } }
-
-      before do
-        expect(Settings).to receive(:[]).with('allocate_docker_host_ports').and_return(false)
+        subject.update(guid)
       end
 
-      it 'should not add host port bindings when starting a container' do
-        expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
-        expect(container).to receive(:start).with(container_start_opts)
-        expect(container).to receive(:json).and_return(container_state)
-        subject.create(guid)
-      end
-    end
-
-    context 'when there are service arbitrary parameters' do
-      let(:parameters) { { 'foo' => 'bar', 'bar' => 'foo' } }
-      let(:env_vars) { ['USER=MY-USER', 'foo=bar', 'bar=foo'] }
-
-      it 'should pass the arbitrary parameters as environment variables' do
-        expect(Docker::Container).to receive(:create).with(container_create_opts).and_return(container)
-        expect(container).to receive(:start).with(container_start_opts)
-        expect(container).to receive(:json).and_return(container_state)
-        subject.create(guid, parameters)
+      context 'when the container does not exists' do
+        it 'should raise an Exception' do
+          expect(Docker::Container).to receive(:get).with(container_name).and_raise(Docker::Error::NotFoundError)
+          expect do
+            subject.update(guid)
+          end.to raise_error(Exceptions::NotFound, "Docker container `#{container_name}' not found")
+        end
       end
     end
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -23,6 +23,7 @@ describe Service do
     'plans'            => [
       double('Plan')
     ],
+    'plan_updateable'  => true,
     'dashboard_client' => {
       'id'           => 'client-id',
       'secret'       => 'client-secret',
@@ -86,12 +87,16 @@ describe Service do
       end
 
       it 'sets the plans field to an empty array' do
-         expect(service.plans).to eq([])
-       end
+        expect(service.plans).to eq([])
+      end
+
+      it 'sets the plan_updateable field to a boolean' do
+        expect(service.plan_updateable).to eq(true)
+      end
 
       it 'sets the dashboard_client field to an empty hash' do
-         expect(service.dashboard_client).to eq({})
-       end
+        expect(service.dashboard_client).to eq({})
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'webmock/rspec'
+require 'docker'
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
In this example, the `-X PUT` (or `-X PATCH`) will recreate the container
using the same port bindings and same volume directory:

![](http://cl.ly/image/2J19322N3Y44/Screen%20Recording%202015-10-06%20at%2008.29%20PM.gif)

The `cf update-service` command in action:

![](http://cl.ly/image/1b3J2x0u1K2z/Screen%20Recording%202015-10-06%20at%2010.17%20PM.gif)